### PR TITLE
Remove redundant re-exports of types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,6 +149,15 @@
 			"resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.16.3.tgz",
 			"integrity": "sha512-5Ksgx9H/Yjz6oamDbmDZstWlJGPTao7shNfambjf8o7OkHxDwAi0AJLQcFwS9pDKI4gQPdiKZXze3nT1eCOViQ=="
 		},
+		"@types/tap": {
+			"version": "14.10.0",
+			"resolved": "https://registry.npmjs.org/@types/tap/-/tap-14.10.0.tgz",
+			"integrity": "sha512-5MqYgn9nfCsPN/KgbIq8XbaO0w5Ktf3awqStD+uHekqWMiLZ12Y4E4g4Ob08wxXSYgpRTe7UFd8z/2AcYn06xA==",
+			"dev": true,
+			"requires": {
+				"@types/node": "*"
+			}
+		},
 		"ajv": {
 			"version": "6.10.0",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 	"author": "Eoin Shanaghy <eoin.shanaghy@fourtheorem.com>",
 	"license": "MIT",
 	"devDependencies": {
+		"@types/tap": "^14.10.0",
 		"tap": "^12.6.2"
 	},
 	"dependencies": {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,11 +1,10 @@
-import tap, { Test } from 'tap';
-
+import tap from 'tap';
 import { StateMachine } from '../dist/state-machine'
-import { Task } from '../dist/state'
+import { Task } from '../dist/task'
 
 const testLambdaArn = "arn:aws:lambda:eu-west-1:123456789123:function:function-name";
 
-tap.test('it creates a state machine', (t: Test) => {
+tap.test('it creates a state machine', t => {
   const startState : Task = {
     Type: "Task",
     Resource: testLambdaArn    


### PR DESCRIPTION
I noticed the types emitted in this package cause errors in TypeScript 3.7, so I've restructured them to use the re-export syntax and avoid the error. As this follows standard ES6 module syntax, this should be backwards compatible and releasable as a patch.

## `diff` of `dist`

```patch
diff old/index.d.ts new/index.d.ts
1,20c1,10
< import { StateMachine } from './state-machine';
< import { State } from './state';
< import { Choice } from './choice';
< import { Fail } from './fail';
< import { Parallel } from './parallel';
< import { Pass } from './pass';
< import { Succeed } from './succeed';
< import { Task } from './task';
< import { Wait } from './wait';
< import { Map } from './map';
< export type StateMachine = StateMachine;
< export type State = State;
< export type Choice = Choice;
< export type Fail = Fail;
< export type Parallel = Parallel;
< export type Pass = Pass;
< export type Succeed = Succeed;
< export type Task = Task;
< export type Wait = Wait;
< export type Map = Map;
---
> export type { StateMachine } from './state-machine';
> export type { State } from './state';
> export type { Choice } from './choice';
> export type { Fail } from './fail';
> export type { Parallel } from './parallel';
> export type { Pass } from './pass';
> export type { Succeed } from './succeed';
> export type { Task } from './task';
> export type { Wait } from './wait';
> export type { Map } from './map';
diff old/map.d.ts new/map.d.ts
15,16d14
< export type StateMachine = StateMachine;
<
diff old/state-machine.d.ts new/state-machine.d.ts
19,20d18
< export type State = State;
<
diff old/state.d.ts new/state.d.ts
16,23d15
< export type Choice = Choice;
< export type Fail = Fail;
< export type Parallel = Parallel;
< export type Pass = Pass;
< export type Succeed = Succeed;
< export type Task = Task;
< export type Wait = Wait;
< export type Map = Map;
```